### PR TITLE
Define `andMap` using `map`

### DIFF
--- a/src/RemoteData.elm
+++ b/src/RemoteData.elm
@@ -343,26 +343,17 @@ Category theory points: This is `apply` with the arguments flipped.
 -}
 andMap : RemoteData e a -> RemoteData e (a -> b) -> RemoteData e b
 andMap wrappedValue wrappedFunction =
-    case ( wrappedFunction, wrappedValue ) of
-        ( Success f, Success value ) ->
-            Success (f value)
+    case wrappedFunction of
+        Success f ->
+            map f wrappedValue
 
-        ( Failure error, _ ) ->
+        Failure error ->
             Failure error
 
-        ( _, Failure error ) ->
-            Failure error
-
-        ( Loading, _ ) ->
+        Loading ->
             Loading
 
-        ( _, Loading ) ->
-            Loading
-
-        ( NotAsked, _ ) ->
-            NotAsked
-
-        ( _, NotAsked ) ->
+        NotAsked ->
             NotAsked
 
 


### PR DESCRIPTION
`andMap` can be defined in terms of `map`, which should help clean up the function a little bit. I noticed this because Haskell requires instances of `Applicative` to also be an instance of `Functor` (see [here](https://hackage.haskell.org/package/base-4.9.0.0/docs/Control-Applicative.html#t:Applicative)).

**P.S.** Thanks for the awesome library! And Happy New Year! 🎉 