### PR TITLE
[doc] Fix getNews example

### DIFF
--- a/src/RemoteData.elm
+++ b/src/RemoteData.elm
@@ -53,8 +53,7 @@ Now we can create an HTTP get:
 
     getNews : Cmd Msg
     getNews =
-        Http.get { url = "/news", expect = expectJson decodeNews }
-            |> RemoteData.fromResult
+        Http.get { url = "/news", expect = expectJson RemoteData.fromResult decodeNews }
             |> Cmd.map NewsResponse
 
 We trigger it in our `init` function:


### PR DESCRIPTION
The [Http.expectJson](https://package.elm-lang.org/packages/elm/http/2.0.0/Http#expectJson) has this signature : `expectString : (Result Error String -> msg) -> Expect msg`.

The getNews example from the doc does not comply with it, hence this PR to clarify :)

Note that I may be totally wrong with this PR, still it may lead to a clearer example :woman_shrugging: 


PSS. thanks for this package  :heart: 