### PR TITLE
Keep data when loading and on error

### DIFF
--- a/src/RemoteData.elm
+++ b/src/RemoteData.elm
@@ -441,7 +441,7 @@ succeed =
 isSuccess : RemoteData e a -> Bool
 isSuccess data =
     case data of
-        Success x ->
+        Success _ ->
             True
 
         _ ->
@@ -453,7 +453,7 @@ isSuccess data =
 isFailure : RemoteData e a -> Bool
 isFailure data =
     case data of
-        Failure x ->
+        Failure _ ->
             True
 
         _ ->

--- a/src/RemoteData/Data.elm
+++ b/src/RemoteData/Data.elm
@@ -1,0 +1,124 @@
+module RemoteData.Data exposing
+    ( Data(..)
+    , andMap
+    , fail
+    , fromMaybe
+    , map
+    , mapError
+    , succeed
+    , toMaybe
+    , withDefault
+    )
+
+{-| A data can have three different states:
+
+  - `Nothing` - No data available, at all
+  - `Failure` - Something went wrong when loadin. Here's the error.
+    The former value is still accessible if any.
+  - `Success` - Everything worked, and here's the data.
+
+-}
+
+
+type Data e a
+    = NoData
+    | Success a
+    | Failure e (Maybe a)
+
+
+succeed : a -> Data e a
+succeed data =
+    Success data
+
+
+fail : e -> Data e a -> Data e a
+fail error data =
+    Failure error (toMaybe data)
+
+
+withDefault : a -> Data e a -> a
+withDefault default =
+    toMaybe >> Maybe.withDefault default
+
+
+fromMaybe : Maybe a -> Data e a
+fromMaybe value =
+    case value of
+        Just a ->
+            Success a
+
+        Nothing ->
+            NoData
+
+
+toMaybe : Data e a -> Maybe a
+toMaybe data =
+    case data of
+        Success x ->
+            Just x
+
+        Failure _ (Just x) ->
+            Just x
+
+        _ ->
+            Nothing
+
+
+map : (a -> b) -> Data e a -> Data e b
+map f data =
+    case data of
+        NoData ->
+            NoData
+
+        Success a ->
+            Success (f a)
+
+        Failure e a ->
+            Failure e (Maybe.map f a)
+
+
+andMap : Data e a -> Data e (a -> b) -> Data e b
+andMap wrappedValue wrappedFunction =
+    case ( wrappedFunction, wrappedValue ) of
+        ( Success f, Success value ) ->
+            Success (f value)
+
+        ( Success f, Failure error (Just value) ) ->
+            Failure error (Just (f value))
+
+        ( Success _, Failure error Nothing ) ->
+            Failure error Nothing
+
+        ( Failure error (Just f), Success value ) ->
+            Failure error (Just (f value))
+
+        ( Failure error (Just f), Failure _ (Just value) ) ->
+            Failure error (Just (f value))
+
+        ( Failure error _, _ ) ->
+            Failure error Nothing
+
+        ( NoData, Failure error _ ) ->
+            Failure error Nothing
+
+        ( _, NoData ) ->
+            NoData
+
+        ( NoData, _ ) ->
+            NoData
+
+
+mapError :
+    (e -> f)
+    -> Data e a
+    -> Data f a
+mapError f data =
+    case data of
+        Failure err x ->
+            Failure (f err) x
+
+        Success x ->
+            Success x
+
+        NoData ->
+            NoData

--- a/tests/DataTest.elm
+++ b/tests/DataTest.elm
@@ -1,0 +1,204 @@
+module DataTest exposing (suite)
+
+import Expect
+import RemoteData.Data as Data exposing (..)
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "The RemoteData.Data module"
+        [ succeedTests
+        , failTests
+        , withDefaultTests
+        , fromMaybeTests
+        , toMaybeTests
+        , mapTests
+        , andMapTests
+        , mapErrorTests
+        ]
+
+
+succeedTests : Test
+succeedTests =
+    test "succeed" <| \_ -> succeed 3 |> Expect.equal (Success 3)
+
+
+failTests : Test
+failTests =
+    let
+        check ( label, input, output ) =
+            test label <|
+                \_ ->
+                    fail "error" input
+                        |> Expect.equal output
+    in
+    describe "fail" <|
+        List.map check
+            [ ( "NoData", NoData, Failure "error" Nothing )
+            , ( "Success", Success 2, Failure "error" (Just 2) )
+            , ( "Failure w data", Failure "smthg" (Just 2), Failure "error" (Just 2) )
+            , ( "Failure w/o data", Failure "smthg" Nothing, Failure "error" Nothing )
+            ]
+
+
+withDefaultTests : Test
+withDefaultTests =
+    let
+        check ( label, input, output ) =
+            test label <|
+                \_ ->
+                    withDefault 5 input
+                        |> Expect.equal output
+    in
+    describe "withDefault" <|
+        List.map check
+            [ ( "Success", Success 2, 2 )
+            , ( "NoData", NoData, 5 )
+            , ( "Failure w data", Failure "error" (Just 2), 2 )
+            , ( "Failure w/o data", Failure "error" Nothing, 5 )
+            ]
+
+
+fromMaybeTests : Test
+fromMaybeTests =
+    let
+        check ( label, input, output ) =
+            test label <|
+                \_ ->
+                    fromMaybe input
+                        |> Expect.equal output
+    in
+    describe "fromMaybe" <|
+        List.map check
+            [ ( "Success", Just 2, Success 2 )
+            , ( "NoData", Nothing, NoData )
+            ]
+
+
+toMaybeTests : Test
+toMaybeTests =
+    let
+        check ( label, input, output ) =
+            test label <|
+                \_ ->
+                    toMaybe input
+                        |> Expect.equal output
+    in
+    describe "toMaybe" <|
+        List.map check
+            [ ( "Success", Success 2, Just 2 )
+            , ( "NoData", NoData, Nothing )
+            , ( "Failure w data", Failure "error" (Just 2), Just 2 )
+            , ( "Failure w/o data", Failure "error" Nothing, Nothing )
+            ]
+
+
+mapTests : Test
+mapTests =
+    let
+        check ( label, input, output ) =
+            test label <|
+                \_ ->
+                    map ((*) 3) input
+                        |> Expect.equal output
+    in
+    describe "map" <|
+        List.map check
+            [ ( "Success", Success 2, Success 6 )
+            , ( "NoData", NoData, NoData )
+            , ( "Failure w data", Failure "error" (Just 2), Failure "error" (Just 6) )
+            , ( "Failure w/o data", Failure "error" Nothing, Failure "error" Nothing )
+            ]
+
+
+andMapTests : Test
+andMapTests =
+    let
+        check ( label, ( fn, value ), output ) =
+            test label <|
+                \_ ->
+                    fn
+                        |> andMap value
+                        |> Expect.equal output
+    in
+    describe "andMap" <|
+        List.map check
+            [ ( "NoData/Success", ( NoData, Success 2 ), NoData )
+            , ( "NoData/NoData", ( NoData, NoData ), NoData )
+            , ( "NoData/Failure w Data"
+              , ( NoData, Failure "err" (Just 2) )
+              , Failure "err" Nothing
+              )
+            , ( "NoData/Failure w/o Data"
+              , ( NoData, Failure "err" Nothing )
+              , Failure "err" Nothing
+              )
+            , ( "Success/Success"
+              , ( Success ((*) 2), Success 2 )
+              , Success 4
+              )
+            , ( "Success/NoData"
+              , ( Success ((*) 2), NoData )
+              , NoData
+              )
+            , ( "Success/Failure w Data"
+              , ( Success ((*) 2), Failure "err" (Just 2) )
+              , Failure "err" (Just 4)
+              )
+            , ( "Success/Failure w/o Data"
+              , ( Success ((*) 2), Failure "err" Nothing )
+              , Failure "err" Nothing
+              )
+            , ( "Failure w Data/Success"
+              , ( Failure "err" (Just ((*) 2)), Success 2 )
+              , Failure "err" (Just 4)
+              )
+            , ( "Failure w Data/NoData"
+              , ( Failure "err" (Just ((*) 2)), NoData )
+              , Failure "err" Nothing
+              )
+            , ( "Failure w Data/Failure w Data"
+              , ( Failure "err" (Just ((*) 2)), Failure "err2" (Just 2) )
+              , Failure "err" (Just 4)
+              )
+            , ( "Failure w Data/Failure w/o Data"
+              , ( Failure "err" (Just ((*) 2)), Failure "err2" Nothing )
+              , Failure "err" Nothing
+              )
+            , ( "Failure w/o Data/Success"
+              , ( Failure "err" Nothing, Success 2 )
+              , Failure "err" Nothing
+              )
+            , ( "Failure w/o Data/NoData"
+              , ( Failure "err" Nothing, NoData )
+              , Failure "err" Nothing
+              )
+            , ( "Failure w/o Data/Failure w Data"
+              , ( Failure "err" Nothing, Failure "err2" (Just 2) )
+              , Failure "err" Nothing
+              )
+            , ( "Failure w/o Data/Failure w/o Data"
+              , ( Failure "err" Nothing, Failure "err2" Nothing )
+              , Failure "err" Nothing
+              )
+            ]
+
+
+mapErrorTests : Test
+mapErrorTests =
+    let
+        check ( label, input, output ) =
+            test label <|
+                \_ ->
+                    input
+                        |> mapError ((++) "_")
+                        |> Expect.equal output
+    in
+    describe "mapError" <|
+        List.map check
+            [ ( "NoData", NoData, NoData )
+            , ( "Success", Success 2, Success 2 )
+            , ( "Failure w data", Failure "err" (Just 2), Failure "_err" (Just 2) )
+            , ( "Failure w/o data", Failure "err" Nothing, Failure "_err" Nothing )
+            ]


### PR DESCRIPTION
The goal here is to keep the data around when loading or when an error occurred so
the UI can still display something. It is an alternative approach to what https://package.elm-lang.org/packages/calions-app/remote-resource/latest/RemoteResource tries to solve.

Since it breaks the API and makes the package less simple (but not too complex either I think) I 
intend to publish it under a new name, but if you are ever interested in this path I would happily
take feedback to get the PR into shape for merge.

Cheers