### PR TITLE
Adds toResult function analogous to toMaybe

### DIFF
--- a/src/RemoteData.elm
+++ b/src/RemoteData.elm
@@ -16,6 +16,7 @@ module RemoteData exposing
     , fromMaybe
     , fromResult
     , toMaybe
+    , toResult
     , asCmd
     , append
     , fromList
@@ -119,6 +120,7 @@ And that's it. A more accurate model of what's happening leads to a better UI.
 @docs fromMaybe
 @docs fromResult
 @docs toMaybe
+@docs toResult
 @docs asCmd
 @docs append
 @docs fromList
@@ -339,6 +341,35 @@ fromResult result =
 toMaybe : RemoteData e a -> Maybe a
 toMaybe =
     map Just >> withDefault Nothing
+
+
+{-| Convert `RemoteData e a` to `Result e a`
+given the default error for `NotAsked` and `Loading` states.
+
+    toResult True NotAsked
+        => Err True
+
+    toResult True Loading
+        => Err True
+
+    toResult True Loading (Failure False)
+        => Err False
+
+    toResult True Loading (Success "it worked!")
+        => Ok "it worked!"
+
+-}
+toResult : e -> RemoteData e a -> Result e a
+toResult defaultError remoteData =
+    case remoteData of
+        Success a ->
+            Ok a
+
+        Failure e ->
+            Err e
+
+        _ ->
+            Err defaultError
 
 
 {-| Append - join two `RemoteData` values together as though

--- a/src/RemoteData.elm
+++ b/src/RemoteData.elm
@@ -347,16 +347,16 @@ toMaybe =
 given the default error for `NotAsked` and `Loading` states.
 
     toResult True NotAsked
-        => Err True
+    --> Err True
 
     toResult True Loading
-        => Err True
+    --> Err True
 
     toResult True Loading (Failure False)
-        => Err False
+    --> Err False
 
     toResult True Loading (Success "it worked!")
-        => Ok "it worked!"
+    --> Ok "it worked!"
 
 -}
 toResult : e -> RemoteData e a -> Result e a


### PR DESCRIPTION
Hello @krisajenkins

I'm big fan of your YT channel / podcast so double thanks for this library as well as your content.

I hope you find a minute to look at this simple PR. Details which I feel are not really that necessary to understand this PR are in the "details" node bellow

<details>

Sometimes I find myself missing this function. I did not implement test for it because

a. I don't have elm-test version compatible with the project
b. There doesn't seem to be test for `toMaybe` function either so I think you might not want to have these simplistic things covered (ie. test would look pretty much like implementation in some ways).

If you want me to add test I can do it in no time.

Otherwise this is the commit message which should explain some decisions:

```
toResult is somewhat compatible with the idea of
toMaybe in that it different constructur per Success then for other cases.

For api it means that function must take is parametrized so that it requires default error from the caller.

This means the implementation is equivalent to composition of Result.fromMaybe and toMaybe in following way:

    toResult e == Maybe.fromResult e << toMaybe

But is not implemented using explicit pattern matching for implementation clarity and performance reasons.
```

</details>