### PR TITLE
Fix toResult documentation

### DIFF
--- a/src/RemoteData.elm
+++ b/src/RemoteData.elm
@@ -361,10 +361,10 @@ given the default error for `NotAsked` and `Loading` states.
     toResult True Loading
     --> Err True
 
-    toResult True Loading (Failure False)
+    toResult True (Failure False)
     --> Err False
 
-    toResult True Loading (Success "it worked!")
+    toResult True (Success "it worked!")
     --> Ok "it worked!"
 
 -}


### PR DESCRIPTION
I found a small typo in the toResult documentation, where two clauses have 3 parameters instead of two. 

Hope it helps!